### PR TITLE
Add support for Firefox

### DIFF
--- a/src/CLIENT/client.py
+++ b/src/CLIENT/client.py
@@ -170,6 +170,8 @@ def startEel():
     try:
         # eel.start('main.html', port=random.choice(range(8000, 8080))) --> use this if you want to open multiple clients on one computer
         eel.start('main.html', port=eelPort)
+    except EnvironmentError:
+        eel.start('main.html', port=eelPort, mode='default')
     except (SystemExit, MemoryError, KeyboardInterrupt): # this catches the exception thrown if the user closes the window
         print("*** Closing the app... ***")
         os._exit(0)  # this is actually super overkill but it works


### PR DESCRIPTION
Add an exception catch so if the user doesn't have chrome installed, use default mode instead which opens firefox, I do not have chrome so I cannot test to see if default mode automatically opens chrome if it's installed. If it does just add mode='default' and skip the exception catch.